### PR TITLE
[bug] 查询已连接设备时，移除状态不为Connected和Offline的无效设备

### DIFF
--- a/src/utils/hdc.ts
+++ b/src/utils/hdc.ts
@@ -31,7 +31,7 @@ export async function listTargets() {
   const targets: Target[] = []
   lines.forEach((line) => {
     const [name, mode, status, host] = line.split(/\t+/)
-    if (status) {
+    if (status === 'Connected' || status === 'Offline') {
       targets.push({ name, mode: mode as TargetMode, status: status as TargetStatus, host })
     }
   })


### PR DESCRIPTION
查询已连接设备时，移除状态不为 `Connected` 和 `Offline` 的无效设备

fix #3 