### PR TITLE
[chore] 移除husky目录的git跟踪

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .DS_Store
+
+.husky

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npx lint-staged


### PR DESCRIPTION
移除husky目录的git跟踪，因为不同的系统，执行`pnpm prepare`生成的文件可能不一样。

比如在`Windows`下的`Git-Bash`中执行，相比于在`Mac`中执行，生成的`pre-commit`，差异多了个空格

```diff
- npx lint-staged
+ npx lint-staged 
```

在 `Windows` 下需要改为执行 `echo npx lint-staged> .husky/pre-commit`，而不是`echo npx lint-staged > .husky/pre-commit`